### PR TITLE
Add HSLA alpha functions

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -14,9 +14,9 @@
 ;; the implementations included with Sass
 ;; (http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html).
 ;; Some additional functions have been added such as `triad` and
-;; `tetrad` for generating sets of colors. 
+;; `tetrad` for generating sets of colors.
 
-;; Converts a color to a hexadecimal string (implementation below). 
+;; Converts a color to a hexadecimal string (implementation below).
 (declare as-hex)
 
 (defrecord CSSColor [red green blue hue saturation lightness alpha]
@@ -66,7 +66,7 @@
 (defn hsl
   "Create an HSL color."
   ([[h s l]]
-     ;; Handle CSSUnits. 
+     ;; Handle CSSUnits.
      (let [[h s l] (map #(get % :magnitude %) [h s l])]
        (if (and (util/between? s 0 100)
                 (util/between? l 0 100))
@@ -97,6 +97,12 @@
   [color]
   (and (map? color)
        (every? color #{:hue :saturation :lightness})))
+
+(defn hsla?
+  "Return true if color is an HSLA color."
+  [color]
+  (and (map? color)
+       (every? color #{:hue :saturation :lightness :alpha})))
 
 (defn color?
   "Return true if x is a color."
@@ -205,6 +211,9 @@
 (def percent-clip
   (partial util/clip 0 100))
 
+(def zero-to-one-clip
+  (partial util/clip 0.0 1.0))
+
 (def rgb-clip
   (partial util/clip 0 255))
 
@@ -236,6 +245,15 @@
    (hex? x) (hex->hsl x)
    (number? x) (hsl [x (percent-clip x) (percent-clip x)])
    :else (throw (ex-info (str "Can't convert " x " to a color.") {}))))
+
+(defn as-hsla
+  "Converts a color to HSLA. Assumes an alpha value of 1.00 unless one is
+  currently set on color."
+  [color]
+  (let [current-alpha (or (:alpha color) 1.00)]
+    (cond
+      (hsla? color) color
+      :else (-> color as-hsl (assoc :alpha current-alpha)))))
 
 (defn- restrict-rgb
   [m]
@@ -277,34 +295,45 @@
     :arglists '([a] [a b] [a b & more])}
   color-div /)
 
-(defn- update-color [color field f v]
-  (let [v (or (:magnitude v) v)]
-    (update-in (as-hsl color) [field] f v)))
+(defn- update-hsla-field
+  [color field f v]
+  (let [v (:magnitude v v)]
+    (-> color as-hsla (update field f v))))
 
 (defn rotate-hue
   "Rotates the hue value of a given color by amount."
   [color amount]
-  (update-color color :hue (comp #(mod % 360) +) amount))
+  (update-hsla-field color :hue (comp #(mod % 360) +) amount))
 
 (defn saturate
   "Increase the saturation value of a given color by amount."
   [color amount]
-  (update-color color :saturation (comp percent-clip +) amount))
+  (update-hsla-field color :saturation (comp percent-clip +) amount))
 
 (defn desaturate
   "Decrease the saturation value of a given color by amount."
   [color amount]
-  (update-color color :saturation (comp percent-clip -) amount))
+  (update-hsla-field color :saturation (comp percent-clip -) amount))
 
 (defn lighten
   "Increase the lightness value a given color by amount."
   [color amount]
-  (update-color color :lightness (comp percent-clip +) amount))
+  (update-hsla-field color :lightness (comp percent-clip +) amount))
 
 (defn darken
   "Decrease the lightness value a given color by amount."
   [color amount]
-  (update-color color :lightness (comp percent-clip -) amount))
+  (update-hsla-field color :lightness (comp percent-clip -) amount))
+
+(defn transparentize
+  "Decreases the alpha value of a given color by amount."
+  [color amount]
+  (update-hsla-field color :alpha (comp zero-to-one-clip -) amount))
+
+(defn opacify
+  "Increases the alpha value of a given color by amount."
+  [color amount]
+  (update-hsla-field color :alpha (comp zero-to-one-clip +) amount))
 
 (defn invert
   "Return the inversion of a color."
@@ -320,7 +349,7 @@
   ([color-1 color-2 & more]
      (reduce mix (mix color-1 color-2) more)))
 
-;;;; Color wheel functions. 
+;;;; Color wheel functions.
 
 (defn complement
   "Return the complement of a color."
@@ -564,12 +593,18 @@
 (defn scale-lightness
   "Scale the lightness of a color by amount"
   [color amount]
-  (update-color color :lightness scale-color-value amount))
+  (update-hsla-field color :lightness scale-color-value amount))
 
 (defn scale-saturation
   "Scale the saturation of a color by amount"
   [color amount]
-  (update-color color :saturation scale-color-value amount))
+  (update-hsla-field color :saturation scale-color-value amount))
+
+(defn scale-alpha
+  "Scales the alpha of a color by amount, which is treated as a percentage.
+  Supply positive values to scale upwards and negative values to scale downwards."
+  [color amount]
+  (update-hsla-field color :alpha #(zero-to-one-clip (* %1 (+ 1 (/ %2 100)))) amount))
 
 (defn- decrown-hex [hex]
   (string/replace hex #"^#" ""))

--- a/test/garden/color_test.cljc
+++ b/test/garden/color_test.cljc
@@ -127,76 +127,53 @@
 (deftest color-functions-test
   (testing "rotate-hue"
     (are [x y] (= x y)
-      (color/rotate-hue hsl-black 0)
-      (color/hsl 0 0 0)
-
-      (color/rotate-hue hsl-black 180)
-      (color/hsl 180 0 0)
-
-      (color/rotate-hue hsl-black 360)
-      (color/hsl 0 0 0)
-
-      (color/rotate-hue hsl-black -360)
-      (color/hsl 0 0 0)
-
-      (color/rotate-hue hsl-black -180)
-      (color/hsl 180 0 0)))
+      (-> hsl-black (color/rotate-hue    0) :hue)   0
+      (-> hsl-black (color/rotate-hue  180) :hue) 180
+      (-> hsl-black (color/rotate-hue  360) :hue)   0
+      (-> hsl-black (color/rotate-hue -360) :hue)   0
+      (-> hsl-black (color/rotate-hue -180) :hue) 180))
 
   (testing "saturate"
     (are [x y] (= x y)
-      (color/saturate hsl-black 0)
-      (color/hsl 0 0 0)
-
-      (color/saturate hsl-black 50)
-      (color/hsl 0 50 0)
-
-      (color/saturate hsl-black 100)
-      (color/hsl 0 100 0)
-
-      (color/saturate hsl-black 200)
-      (color/hsl 0 100 0)))
+      (-> hsl-black (color/saturate   0) :saturation)   0
+      (-> hsl-black (color/saturate  50) :saturation)  50
+      (-> hsl-black (color/saturate 100) :saturation) 100
+      (-> hsl-black (color/saturate 200) :saturation) 100))
 
   (testing "desaturate"
     (are [x y] (= x y)
-      (color/desaturate hsl-red 0)
-      (color/hsl 0 100 50)
-
-      (color/desaturate hsl-red 50)
-      (color/hsl 0 50 50)
-
-      (color/desaturate hsl-red 100)
-      (color/hsl 0 0 50)
-
-      (color/desaturate hsl-red 200)
-      (color/hsl 0 0 50)))
+      (-> hsl-red (color/desaturate   0) :saturation) 100
+      (-> hsl-red (color/desaturate  50) :saturation)  50
+      (-> hsl-red (color/desaturate 100) :saturation)   0
+      (-> hsl-red (color/desaturate 200) :saturation)   0))
 
   (testing "lighten"
     (are [x y] (= x y)
-      (color/lighten rgb-black 0)
-      (color/hsl 0 0 0)
-
-      (color/lighten rgb-black 50)
-      (color/hsl 0 0 50)
-
-      (color/lighten rgb-black 100)
-      (color/hsl 0 0 100)
-
-      (color/lighten rgb-black 200)
-      (color/hsl 0 0 100)))
+      (-> rgb-black (color/lighten   0) :lightness)   0
+      (-> rgb-black (color/lighten  50) :lightness)  50
+      (-> rgb-black (color/lighten 100) :lightness) 100
+      (-> rgb-black (color/lighten 200) :lightness) 100))
 
   (testing "darken"
     (are [x y] (= x y)
-      (color/darken rgb-white 0)
-      (color/hsl 0 0 100)
+      (-> rgb-white (color/darken   0) :lightness) 100
+      (-> rgb-white (color/darken  50) :lightness)  50
+      (-> rgb-white (color/darken 100) :lightness)   0
+      (-> rgb-white (color/darken 200) :lightness)   0))
 
-      (color/darken rgb-white 50)
-      (color/hsl 0 0 50)
+  (testing "transparentize"
+    (are [x y] (= x y)
+      (-> (color/hsla 180 50 50 0.50) (color/transparentize 0.10) :alpha) 0.40
+      (-> (color/hsla 180 50 50 0.50) (color/transparentize 0.50) :alpha) 0.00
+      (-> (color/hsla 180 50 50 1.00) (color/transparentize 0.50) :alpha) 0.50
+      (-> (color/hsla 180 50 50 0.01) (color/transparentize 0.10) :alpha) 0.00))
 
-      (color/darken rgb-white 100)
-      (color/hsl 0 0 0)
-
-      (color/darken rgb-white 200)
-      (color/hsl 0 0 0)))
+  (testing "opacify"
+    (are [x y] (= x y)
+      (-> (color/hsla 180 50 50 0.50) (color/opacify 0.10) :alpha) 0.60
+      (-> (color/hsla 180 50 50 0.50) (color/opacify 0.50) :alpha) 1.00
+      (-> (color/hsla 180 50 50 1.00) (color/opacify 0.50) :alpha) 1.00
+      (-> (color/hsla 180 50 50 0.00) (color/opacify 0.12) :alpha) 0.12))
 
   (testing "invert"
     (are [x y] (= x y)
@@ -218,9 +195,14 @@
     (is (= 25 (-> (color/hsl 50 50 50) (color/scale-lightness -50) :lightness)))))
 
 (deftest scale-saturation-test []
-  (testing "scale-lightness"
+  (testing "scale-saturation"
     (is (= 75 (-> (color/hsl 50 50 50) (color/scale-saturation 50) :saturation)))
     (is (= 25 (-> (color/hsl 50 50 50) (color/scale-saturation -50) :saturation)))))
+
+(deftest scale-alpha-test []
+  (testing "scale-alpha"
+    (is (= 0.75 (-> (color/hsla 180 50 50 0.50) (color/scale-alpha  50) :alpha)))
+    (is (= 0.25 (-> (color/hsla 180 50 50 0.50) (color/scale-alpha -50) :alpha)))))
 
 (deftest hex-tests []
   (testing "decrown hex"


### PR DESCRIPTION
Adds functions for manipulations a color's alpha values. These are
analogous to the existing saturate, lighten, etc functions.

Will replace anonymous function in src/garden/color.cljc:607 in
scale-alpha/2 with a call to the updated scale-color-value private
helper that is defined in PR #149 assuming that gets merged.

Additionally, some of the test coverage should be increased, but all of 
these functions' impls rely on the scale-color-value, only a subset of tests 
could be added until the updated version is merged.